### PR TITLE
Add --overrides-file and --allow-system-uid options.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -24,7 +24,7 @@ dependencies = [
 
 [[package]]
 name = "authorized-keys-github"
-version = "0.1.0"
+version = "0.0.5"
 dependencies = [
  "clap",
  "fstrings",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -27,7 +27,6 @@ name = "authorized-keys-github"
 version = "0.0.5"
 dependencies = [
  "clap",
- "fstrings",
  "reqwest",
  "sshkeys",
  "tempfile",
@@ -205,28 +204,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a9c384f161156f5260c24a097c56119f9be8c798586aecc13afbcbe7b7e26bf8"
 dependencies = [
  "percent-encoding",
-]
-
-[[package]]
-name = "fstrings"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7845a0f15da505ac36baad0486612dab57f8b8d34e19c5470a265bbcdd572ae6"
-dependencies = [
- "fstrings-proc-macro",
- "proc-macro-hack",
-]
-
-[[package]]
-name = "fstrings-proc-macro"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63b58c0e7581dc33478a32299182cbe5ae3b8c028be26728a47fb0a113c92d9d"
-dependencies = [
- "proc-macro-hack",
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]
@@ -645,12 +622,6 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
-
-[[package]]
-name = "proc-macro-hack"
-version = "0.5.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbf0c48bc1d91375ae5c3cd81e3722dff1abcf81a30960240640d223f59fe0e5"
 
 [[package]]
 name = "proc-macro2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,6 @@ edition = "2018"
 
 [dependencies]
 clap = "2.33.0"
-fstrings = "0.2.2"
 sshkeys = "0.3.2"
 users = "0.9.1"
 tempfile = "3.1.0"

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,9 @@ ARG GID=1000
 RUN useradd -u ${UID} staticfloat
 RUN echo "staticfloat ALL = NOPASSWD: ALL" >> /etc/sudoers
 
+# Create `keno` user that will not work by default, because he's a system user
+RUN useradd -u 900 keno
+
 # Copy in our build artifacts
 COPY runtests.sh /var/runtests.sh
 COPY target/release/authorized-keys-github /usr/local/bin/authorized-keys-github

--- a/Makefile
+++ b/Makefile
@@ -70,10 +70,10 @@ TARGET_TRIPLETS := aarch64-unknown-linux-gnu \
 $(foreach triplet,$(TARGET_TRIPLETS),$(eval multibuild: target/$(triplet)/release/authorized-keys-github))
 
 check:
-	$(call docker_exec,rust,cargo fmt --color=always --all -- --check)
+	$(call docker_exec,rust,cargo fmt --all -- --check)
 
 format:
-	$(call docker_exec,rust,cargo fmt --color=always --all)
+	$(call docker_exec,rust,cargo fmt --all)
 
 .PHONY: test build
 test: $(NATIVE_EXE)

--- a/README.md
+++ b/README.md
@@ -13,6 +13,18 @@ For this tool to work, users must use the same username as their GitHub username
 
 The tool will attempt to build a cache of SSH key fingerprints at `/var/keys` by default; to change this, use the `--keys-dir` option.
 
+## Overriding local usernames and usage for system accounts
+
+In the event that you want to use this tool with local usernames that you do not control (such as the `root` user on a single-user system like OpenWRT) you can use the `--overrides-file` argument to explicitly map UIDs to GitHub usernames.
+A simple example is given here:
+```
+# Allow users `keno` and `staticfloat` to login as `root`
+0: keno staticfloat
+```
+A more complete example overrides file with comments is [given in `example.overrides`](./example.overrides).
+Note that overrides files must be owned by the user that the command is being run by (usually `root`) and cannot be writable by any other user or group.
+In order to actually login as `root` (or any system user account with a UID <1000) you must explicitly whitelist the account by passing `--allow-system-uid=xxx` to the command.
+
 ## Usage Warning
 
 Although we have taken some pains to test this in exceptional circumstances (such as disk space exhaustion, read-only filesystems, etc...) it is possible there remain serious bugs that can lock you out of your server.

--- a/example.overrides
+++ b/example.overrides
@@ -1,0 +1,24 @@
+# This is an "overrides" file, it allows the administrator to provide
+# overrides on which UIDs should be mapped to which GitHub usernames.
+# The syntax is a series of lines of the form:
+#
+#   <uid>: username1 username2 ...
+#
+# Multiple usernames are permissable, to allow multiple github users
+# to log in to a shared account (e.g. `root` on single-user systems).
+# Note that you must pass `--allow-system-uid=xxx` for each UID under
+# 1000 for these to be accepted.
+#
+# If a UID is listed here, the typical user database in `/etc/passwd`
+# is not consulted at all; this provides a secure mechanism by which
+# to map local usernames which are constrained in some way to github
+# usernames that you do have full control over.
+#
+# Needless to say, lines starting with '#' are ignored.
+# What follows here is a series of examples:
+
+# A single UID can be mapped to multiple GitHub usernames
+0: keno staticfloat
+
+# A GitHub username can be assigned to multiple UIDs
+1000: staticfloat

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,63 +1,75 @@
 extern crate clap;
-#[macro_use]
-extern crate fstrings;
 extern crate reqwest;
 extern crate tempfile;
 extern crate tokio;
 extern crate users;
-use clap::{App,crate_version,crate_name,crate_authors};
+use clap::{crate_authors, crate_name, crate_version, App};
+use std::collections::{HashMap, HashSet};
+use std::error::Error;
 use std::fs::File;
 use std::io::prelude::*;
-use std::io::SeekFrom;
-use std::io::Write;
+use std::io::{BufReader, SeekFrom, Write};
+use std::os::unix::fs::{MetadataExt, PermissionsExt};
 use std::process;
 use std::time::SystemTime;
 use tempfile::NamedTempFile;
-use users::get_user_by_uid;
+use users::{get_current_uid, get_user_by_uid};
 
 static GITHUB_URL: &str = "https://github.com";
 static DEFAULT_KEYS_DIRECTORY: &str = "/var/keys";
 
 fn uid_keys_file(keys_dir: &str, uid: u32) -> String {
-    return f!("{keys_dir}/{uid}.keys");
+    return format!("{keys_dir}/{uid}.keys");
+}
+
+fn get_usernames(
+    uid: &u32,
+    overrides: HashMap<u32, Vec<String>>,
+) -> Result<Vec<String>, Box<dyn Error>> {
+    // If we have overrides for the given `uid`, return those usernames
+    if overrides.contains_key(uid) {
+        return Ok(overrides.get(uid).unwrap().clone());
+    }
+
+    // Otherwise, return the one username we get from the system
+    let username = match get_user_by_uid(*uid) {
+        None => Err(format!("Username for uid '{}' not found", uid))?,
+        Some(user) => match user.name().to_str() {
+            Some(username) => username.to_string(),
+            None => Err(format!("Username for uid '{}' unwrappable", uid))?,
+        },
+    };
+
+    return Ok(vec![username]);
 }
 
 async fn refresh_keys_from_github(
     uid: u32,
+    usernames: &Vec<String>,
     keys_dir: &str,
     keyfile_contents: &mut String,
 ) -> Result<File, String> {
-    eprintln!("Refreshing keys from github");
-    let user = get_user_by_uid(uid);
-    if user.is_none() {
-        panic!("Username for uid {} not found", uid);
-    }
+    for username in usernames {
+        eprintln!("Refreshing keys from github for user {username}");
+        let response_future = reqwest::get(&format!("{GITHUB_URL}/{username}.keys")).await;
+        if response_future.is_err() {
+            panic!("Request to GitHub failed: {}", response_future.unwrap_err());
+        }
 
-    let user = user.unwrap();
-    let username = user.name().to_str();
-    if username.is_none() {
-        panic!("{}", "Failed to get username");
-    }
+        let response = response_future.ok().unwrap();
+        if !response.status().is_success() {
+            return Err(format!(
+                "Remote had invalid request code: {}",
+                response.status()
+            ));
+        }
 
-    let username = username.unwrap();
-    let response_future = reqwest::get(&f!("{GITHUB_URL}/{username}.keys")).await;
-    if response_future.is_err() {
-        panic!("Request to GitHub failed: {}", response_future.unwrap_err());
+        let body = response.text().await;
+        if body.is_err() {
+            return Err(format!("Failed to retrieve body: {}", body.unwrap_err()));
+        }
+        keyfile_contents.push_str(&body.unwrap());
     }
-
-    let response = response_future.ok().unwrap();
-    if !response.status().is_success() {
-        return Err(format!(
-            "Remote had invalid request code: {}",
-            response.status()
-        ));
-    }
-
-    let body = response.text().await;
-    if body.is_err() {
-        return Err(format!("Failed to retrieve body: {}", body.unwrap_err()));
-    }
-    keyfile_contents.clone_from(&body.unwrap());
 
     let mut file = match NamedTempFile::new_in(keys_dir) {
         Ok(file) => file,
@@ -68,6 +80,7 @@ async fn refresh_keys_from_github(
     if written.is_err() {
         return Err(format!("Failed to write key: {}", written.unwrap_err()));
     }
+
     return match file.persist(uid_keys_file(keys_dir, uid)) {
         Ok(mut file) => {
             let _ = &file.seek(SeekFrom::Start(0));
@@ -111,6 +124,55 @@ fn is_outdated(time: SystemTime) -> bool {
     };
 }
 
+fn load_overrides_file(path: &str) -> Result<HashMap<u32, Vec<String>>, Box<dyn Error>> {
+    let mut mapping = HashMap::new();
+    let file = File::open(path)?;
+    let meta = file.metadata()?;
+    let curr_uid = get_current_uid();
+    let mode = meta.permissions().mode();
+    if (meta.uid() != curr_uid) || (mode & 0o022 != 0) {
+        Err(format!("Must be owned by current user (uid: {curr_uid}) and not writable by anyone else (permissions: {:o})", mode))?;
+    }
+    for line in BufReader::new(file).lines() {
+        if let Ok(l) = line {
+            if l.starts_with("#") || l.is_empty() {
+                continue;
+            }
+            let uid_names: Vec<_> = l.split(":").collect();
+            let uid_str = uid_names[0];
+            let uid: u32 = match uid_str.parse() {
+                Ok(uid) => uid,
+                Err(e) => Err(format!("Invalid UID '{uid_str}': {}", e))?,
+            };
+            let names: Vec<String> = uid_names[1]
+                .split_whitespace()
+                .map(|s| s.to_owned())
+                .collect();
+
+            // Error out if the overrides file contains a duplicate mapping for a UID
+            if mapping.contains_key(&uid) {
+                Err(format!("Duplicate mapping for UID '{uid}'"))?;
+            }
+            mapping.insert(uid, names);
+        }
+    }
+    return Ok(mapping);
+}
+
+fn parse_uids(uids_str: Option<clap::Values>) -> Result<HashSet<u32>, Box<dyn Error>> {
+    let mut uids = HashSet::new();
+    if uids_str.is_some() {
+        for uid_str in uids_str.unwrap() {
+            let uid = match uid_str.parse() {
+                Ok(uid) => uid,
+                Err(e) => Err(format!("Invalid UID '{uid_str}': {}", e))?,
+            };
+            uids.insert(uid);
+        }
+    }
+    return Ok(uids);
+}
+
 #[tokio::main]
 async fn main() {
     let matches = App::new(crate_name!())
@@ -118,29 +180,59 @@ async fn main() {
         .author(crate_authors!("\n"))
         .about("Retrieve SSH keys from GitHub auth with local caching")
         .args_from_usage(
-            "--fp=[fp]        'The fingerprint for the requested key'
-             --keys-dir=[kd]  'The keys directory (default: /var/keys)'
-             <uid>            'The UID for which to retrieve authorized keys'",
+            "--fp=[fp]                     'The fingerprint for the requested key'
+             --keys-dir=[kd]               'The keys directory (default: /var/keys)'
+             --overrides-file=[af]          'The path to an overrides file (default: none)'
+             --allow-system-uid=[uid]...   'Enable operation for a specific system UID (<1000)'
+             <uid>                         'The UID for which to retrieve authorized keys'",
         )
         .get_matches();
-    let uid = matches.value_of("uid");
-    let keys_dir_arg = matches.value_of("keys-dir");
-    let mut requested_fp = matches.value_of("fp");
-    if !uid.is_some() {
-        eprintln!("ERROR: uid is required");
-        process::exit(1);
-    }
-    let uid = uid.unwrap().parse::<u32>();
-    if !uid.is_ok() {
-        eprintln!("ERROR: uid must be an integer");
-        process::exit(1);
-    }
-    let uid = uid.ok().unwrap();
-    if uid < 1000 {
+
+    // If we've been given an override file, read it in, otherwise just use an empty mapping
+    let overrides_file = matches.value_of("overrides-file");
+    let overrides_mapping = match overrides_file {
+        None => HashMap::new(),
+        Some(path) => match load_overrides_file(path) {
+            Ok(overrides_mapping) => overrides_mapping,
+            // If we tried to get an override mapping, but it failed in some way, panic.
+            Err(e) => {
+                eprintln!("ERROR: Invalid overrides file {path}: {}", e);
+                process::exit(1);
+            }
+        },
+    };
+
+    let allowed_system_uids = match parse_uids(matches.values_of("allow-system-uid")) {
+        Ok(uids) => uids,
+        Err(e) => {
+            eprintln!("ERROR: Unable to parse system UID: {}", e);
+            process::exit(1);
+        }
+    };
+
+    let uid = match matches.value_of("uid") {
+        Some(uid) => uid.parse().expect("ERROR: uid must be an integer"),
+        None => {
+            eprintln!("ERROR: uid is required");
+            process::exit(1);
+        }
+    };
+    if uid < 1000 && !allowed_system_uids.contains(&uid) {
         eprintln!("ERROR: UID must be > 1000");
         process::exit(1);
     }
 
+    // Determine the usernames we're going to query
+    let usernames = match get_usernames(&uid, overrides_mapping) {
+        Ok(usernames) => usernames,
+        Err(e) => {
+            eprintln!("Unable to determine username(s) for {uid}: {}", e);
+            process::exit(1);
+        }
+    };
+
+    // Only allow SHA256 fingerprints
+    let mut requested_fp = matches.value_of("fp");
     if requested_fp.is_some() {
         let unwrap_requested_fp = requested_fp.unwrap();
         let separator = unwrap_requested_fp.find(':').unwrap();
@@ -148,12 +240,11 @@ async fn main() {
         requested_fp = Some(unwrap_requested_fp.get(separator + 1..).unwrap());
     }
 
-    let keys_dir: &str;
-    if keys_dir_arg.is_some() {
-        keys_dir = keys_dir_arg.unwrap();
-    } else {
-        keys_dir = DEFAULT_KEYS_DIRECTORY;
-    }
+    // Parse out the keys directory
+    let keys_dir = match matches.value_of("keys-dir") {
+        Some(keys_dir) => keys_dir,
+        None => DEFAULT_KEYS_DIRECTORY,
+    };
 
     let mut keyfile_contents = String::new();
     let file = File::open(uid_keys_file(keys_dir, uid));
@@ -166,7 +257,7 @@ async fn main() {
             Err(_) => false,
         }
     {
-        _ = refresh_keys_from_github(uid, keys_dir, &mut keyfile_contents).await;
+        _ = refresh_keys_from_github(uid, &usernames, keys_dir, &mut keyfile_contents).await;
         _ = print_requested_key(&keyfile_contents, requested_fp);
     } else {
         let _read = file.unwrap().read_to_string(&mut keyfile_contents);
@@ -174,7 +265,7 @@ async fn main() {
             Ok(ok) => ok,
             Err(_) => false,
         } {
-            _ = refresh_keys_from_github(uid, keys_dir, &mut keyfile_contents).await;
+            _ = refresh_keys_from_github(uid, &usernames, keys_dir, &mut keyfile_contents).await;
             _ = print_requested_key(&keyfile_contents, requested_fp);
         }
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,7 +5,7 @@ extern crate reqwest;
 extern crate tempfile;
 extern crate tokio;
 extern crate users;
-use clap::App;
+use clap::{App,crate_version,crate_name,crate_authors};
 use std::fs::File;
 use std::io::prelude::*;
 use std::io::SeekFrom;
@@ -113,10 +113,10 @@ fn is_outdated(time: SystemTime) -> bool {
 
 #[tokio::main]
 async fn main() {
-    let matches = App::new("authorized-keys-github")
-        .version("0.1")
-        .author("Keno Fischer <keno@juliacomputing.com>")
-        .about("Retrieve SSH keys from GitHub auth local caching")
+    let matches = App::new(crate_name!())
+        .version(crate_version!())
+        .author(crate_authors!("\n"))
+        .about("Retrieve SSH keys from GitHub auth with local caching")
         .args_from_usage(
             "--fp=[fp]        'The fingerprint for the requested key'
              --keys-dir=[kd]  'The keys directory (default: /var/keys)'


### PR DESCRIPTION
These options make it possible to actually use this tool on single-user
systems like OpenWRT, where individual users don't make much sense but
we still want to be able to use the github-provided SSH key fingerprint
checking.  The design is to allow explicit whitelisting of system UIDs,
then to provide an overrides file that maps UIDs to (potentially
multiple) GitHub usernames.